### PR TITLE
Feat dynamic logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,13 @@
 
 This simple library implements a PSR compatible logger that routes all messages to a Yii Logger.
 Use this if you have a library that needs such a logger and you want to forward the messages to your existing Logger.
+
+## Logger adapter
+
+The `Logger` adapter class takes a Yii `Logger` object and implements the `LoggerInterface`.
+
+## DynamicLogger
+
+Since Yii2 uses mutability a lot, the `Logger` adapter might hold a reference to an old Yii `Logger`. To work properly
+with the Service Locator pattern we must use it on every call. `DynamicLogger` does this while internally using the `Logger`
+and recreating it when needed.

--- a/ecs.php
+++ b/ecs.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
+use PhpCsFixer\Fixer\Import\NoUnusedImportsFixer;
+use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 use Symplify\EasyCodingStandard\ValueObject\Option;
 use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
@@ -21,6 +23,8 @@ return static function (ECSConfig $ecsConfig): void {
     $ecsConfig->ruleWithConfiguration(ArraySyntaxFixer::class, [
         'syntax' => 'short'
     ]);
+    $ecsConfig->rule(NoUnusedImportsFixer::class);
+    $ecsConfig->rule(DeclareStrictTypesFixer::class);
 
 
 

--- a/src/DynamicLogger.php
+++ b/src/DynamicLogger.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii\psr;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerTrait;
+use WeakReference;
+
+/**
+ * Implements a PSR logger that routes messages to the current Yii Logger.
+ */
+final class DynamicLogger implements LoggerInterface
+{
+    use LoggerTrait;
+    private ?Logger $logger = null;
+    /**
+     * Note that using a weak reference here is merely a good practice.
+     * In reality the ->get() will never return null since the underlying logger doesn't use a weak reference.
+     * @var WeakReference<\yii\log\Logger>|null
+     */
+    private ?WeakReference $yiiLogger = null;
+    private function getLogger(): Logger
+    {
+        if (!isset($this->logger, $this->yiiLogger) || \Yii::getLogger() !== $this->yiiLogger->get()) {
+            $this->yiiLogger = WeakReference::create(\Yii::getLogger());
+            $this->logger = new Logger(\Yii::getLogger());
+        }
+        return $this->logger;
+    }
+    public function log($level, \Stringable|string $message, array $context = []): void
+    {
+        $this->getLogger()->log($level, $message, $context);
+    }
+}

--- a/src/DynamicLogger.php
+++ b/src/DynamicLogger.php
@@ -6,7 +6,6 @@ namespace yii\psr;
 
 use Psr\Log\LoggerInterface;
 use Psr\Log\LoggerTrait;
-use WeakReference;
 
 /**
  * Implements a PSR logger that routes messages to the current Yii Logger.
@@ -15,16 +14,11 @@ final class DynamicLogger implements LoggerInterface
 {
     use LoggerTrait;
     private ?Logger $logger = null;
-    /**
-     * Note that using a weak reference here is merely a good practice.
-     * In reality the ->get() will never return null since the underlying logger doesn't use a weak reference.
-     * @var WeakReference<\yii\log\Logger>|null
-     */
-    private ?WeakReference $yiiLogger = null;
+    private \yii\log\Logger|null $yiiLogger = null;
     private function getLogger(): Logger
     {
-        if (!isset($this->logger, $this->yiiLogger) || \Yii::getLogger() !== $this->yiiLogger->get()) {
-            $this->yiiLogger = WeakReference::create(\Yii::getLogger());
+        if (!isset($this->logger, $this->yiiLogger) || \Yii::getLogger() !== $this->yiiLogger) {
+            $this->yiiLogger = \Yii::getLogger();
             $this->logger = new Logger(\Yii::getLogger());
         }
         return $this->logger;

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -1,12 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace yii\psr;
 
 use Psr\Log\InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LoggerTrait;
 use Psr\Log\LogLevel;
-use Yii;
 use yii\log\Logger as YiiLogger;
 
 final class Logger implements LoggerInterface

--- a/tests/DynamicLoggerTest.php
+++ b/tests/DynamicLoggerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+namespace yiiunit\extensions\psr;
+
+use PHPUnit\Framework\TestCase;
+use yii\log\Logger as YiiLogger;
+use yii\psr\DynamicLogger;
+
+/**
+ * @covers \yii\psr\DynamicLogger
+ */
+final class DynamicLoggerTest extends TestCase
+{
+    public function testLoggerUsesCurrent(): void
+    {
+        $yiiLogger1 = $this->getMockBuilder(YiiLogger::class)->getMock();
+        $yiiLogger1->expects($this->once())->method('log')->with('test1', YiiLogger::LEVEL_INFO, );
+
+        $yiiLogger2 = $this->getMockBuilder(YiiLogger::class)->getMock();
+        $yiiLogger2->expects($this->once())->method('log')->with('test2', YiiLogger::LEVEL_INFO, );
+
+        $logger = new DynamicLogger();
+        \Yii::setLogger($yiiLogger1);
+
+        $logger->info('test1');
+
+        \Yii::setLogger($yiiLogger2);
+        $logger->info('test2');
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 // ensure we get report on all possible php errors
 error_reporting(-1);
 


### PR DESCRIPTION
This implements a dynamic logger, dynamic in the sense that it always uses whatever the current logger configured in `Yii::getLogger()` is.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | https://github.com/yiisoft/yii2-symfonymailer/issues/26
