### PR TITLE
Drop support for php 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,16 +23,16 @@
         }
     ],
     "require": {
-        "php": ">=8",
+        "php": ">=8.1",
         "yiisoft/yii2": ">=2.0.4",
         "psr/log": "^3"
     },
     "require-dev": {
-        "phpunit/phpunit": "9.5.10",
+        "phpunit/phpunit": "^10",
         "symplify/easy-coding-standard": "^10.1",
-        "vimeo/psalm": "^4.22",
+        "vimeo/psalm": "^5",
         "captainhook/plugin-composer": "^5.3",
-        "phpstan/phpstan": "^1.8",
+        "phpstan/phpstan": "^1.9",
         "ramsey/conventional-commits": "^1.3"
     },
     "repositories": [

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,20 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit bootstrap="./tests/bootstrap.php"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         forceCoversAnnotation="true"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Yii2-swiftmailer Test Suite">
-            <directory>./tests</directory>
-        </testsuite>
-    </testsuites>
-    <coverage>
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
-    </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./tests/bootstrap.php" colors="true" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" cacheDirectory=".phpunit.cache" requireCoverageMetadata="true">
+  <testsuites>
+    <testsuite name="Yii2-swiftmailer Test Suite">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
 </phpunit>


### PR DESCRIPTION
This drops support for php8.0 and upgrades dev dependencies to the latest versions.
Merging this will lead to a new major version being released.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️

